### PR TITLE
Add synchronized hero and chair animation to game screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,12 @@
 
         <div id="game-screen" class="game-screen">
             <div class="background-image" id="background"></div>
-            <div id="character-sprite-container"></div> <div class="message-box">
+            <div id="hero-chair-container">
+                <div id="hero-sprite" class="scene-sprite hero"></div>
+                <div id="chair-sprite" class="scene-sprite chair"></div>
+            </div>
+            <div id="character-sprite-container"></div>
+            <div class="message-box">
                 <p class="message-text" id="quest-text"></p>
                 <div class="choice-container" id="choice-buttons"></div>
             </div>

--- a/script.js
+++ b/script.js
@@ -13,6 +13,8 @@ const chairDescription = document.getElementById('chair-description');
 const purchaseLink = document.getElementById('purchase-link');
 const bgm = document.getElementById('bgm');
 const sfxSelect = document.getElementById('sfx-select'); // 効果音要素を追加
+const heroSceneSprite = document.getElementById('hero-sprite');
+const chairSceneSprite = document.getElementById('chair-sprite');
 
 // 椅子データ (変更なし)
 const chairs = {
@@ -123,6 +125,8 @@ function loadQuest(questId) {
         return;
     }
 
+    animateHeroAndChair();
+
     // 古いタイピングアニメーションをクリア
     if (typingInterval) {
         clearInterval(typingInterval);
@@ -165,6 +169,21 @@ function loadQuest(questId) {
         button.onclick = () => loadQuest(choice.next);
         choiceButtonsContainer.appendChild(button);
     });
+}
+
+function animateHeroAndChair() {
+    if (!heroSceneSprite || !chairSceneSprite) {
+        return;
+    }
+
+    heroSceneSprite.classList.remove('animate');
+    chairSceneSprite.classList.remove('animate');
+
+    // Reflow to restart the animation
+    void heroSceneSprite.offsetWidth;
+
+    heroSceneSprite.classList.add('animate');
+    chairSceneSprite.classList.add('animate');
 }
 
 // 結果画面の表示

--- a/style.css
+++ b/style.css
@@ -58,6 +58,56 @@ body {
     transition: background-image 0.5s ease;
 }
 
+#hero-chair-container {
+    position: absolute;
+    top: 20px;
+    left: 0;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    gap: 40px;
+    z-index: 7;
+    pointer-events: none;
+}
+
+.scene-sprite {
+    width: clamp(64px, 18vmin, 90px);
+    height: clamp(64px, 18vmin, 90px);
+    background-repeat: no-repeat;
+    background-size: contain;
+    image-rendering: pixelated;
+}
+
+.scene-sprite.hero {
+    background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2080%2080%27%3E%0A%20%20%3Crect%20width%3D%2780%27%20height%3D%2780%27%20fill%3D%27none%27%2F%3E%0A%20%20%3Ccircle%20cx%3D%2740%27%20cy%3D%2720%27%20r%3D%2712%27%20fill%3D%27%23f6d7b0%27%2F%3E%0A%20%20%3Crect%20x%3D%2728%27%20y%3D%2732%27%20width%3D%2724%27%20height%3D%2726%27%20rx%3D%276%27%20fill%3D%27%232f6bff%27%2F%3E%0A%20%20%3Crect%20x%3D%2720%27%20y%3D%2732%27%20width%3D%2712%27%20height%3D%2724%27%20fill%3D%27%231841b5%27%2F%3E%0A%20%20%3Crect%20x%3D%2748%27%20y%3D%2732%27%20width%3D%2712%27%20height%3D%2724%27%20fill%3D%27%231841b5%27%2F%3E%0A%20%20%3Crect%20x%3D%2730%27%20y%3D%2758%27%20width%3D%278%27%20height%3D%2716%27%20fill%3D%27%23472615%27%2F%3E%0A%20%20%3Crect%20x%3D%2742%27%20y%3D%2758%27%20width%3D%278%27%20height%3D%2716%27%20fill%3D%27%23472615%27%2F%3E%0A%20%20%3Crect%20x%3D%2726%27%20y%3D%2712%27%20width%3D%2728%27%20height%3D%2712%27%20fill%3D%27%23c92034%27%2F%3E%0A%20%20%3Crect%20x%3D%2728%27%20y%3D%2712%27%20width%3D%2724%27%20height%3D%278%27%20fill%3D%27%23efb700%27%2F%3E%0A%20%20%3Crect%20x%3D%2712%27%20y%3D%2740%27%20width%3D%2712%27%20height%3D%278%27%20fill%3D%27%23f6d7b0%27%2F%3E%0A%20%20%3Crect%20x%3D%2756%27%20y%3D%2740%27%20width%3D%2712%27%20height%3D%278%27%20fill%3D%27%23f6d7b0%27%2F%3E%0A%3C%2Fsvg%3E");
+}
+
+.scene-sprite.chair {
+    background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2080%2080%27%3E%0A%20%20%3Crect%20width%3D%2780%27%20height%3D%2780%27%20fill%3D%27none%27%2F%3E%0A%20%20%3Crect%20x%3D%2718%27%20y%3D%2732%27%20width%3D%2744%27%20height%3D%2714%27%20rx%3D%274%27%20fill%3D%27%23c97835%27%2F%3E%0A%20%20%3Crect%20x%3D%2722%27%20y%3D%2724%27%20width%3D%2736%27%20height%3D%2712%27%20rx%3D%274%27%20fill%3D%27%238b5122%27%2F%3E%0A%20%20%3Crect%20x%3D%2718%27%20y%3D%2746%27%20width%3D%2744%27%20height%3D%2710%27%20rx%3D%273%27%20fill%3D%27%239e5d28%27%2F%3E%0A%20%20%3Crect%20x%3D%2720%27%20y%3D%2756%27%20width%3D%278%27%20height%3D%2718%27%20fill%3D%27%235f3818%27%2F%3E%0A%20%20%3Crect%20x%3D%2752%27%20y%3D%2756%27%20width%3D%278%27%20height%3D%2718%27%20fill%3D%27%235f3818%27%2F%3E%0A%20%20%3Crect%20x%3D%2714%27%20y%3D%2726%27%20width%3D%276%27%20height%3D%2726%27%20fill%3D%27%235f3818%27%2F%3E%0A%20%20%3Crect%20x%3D%2760%27%20y%3D%2726%27%20width%3D%276%27%20height%3D%2726%27%20fill%3D%27%235f3818%27%2F%3E%0A%3C%2Fsvg%3E");
+}
+
+#hero-sprite.animate {
+    animation: hero-slide 0.9s ease-in-out;
+}
+
+#chair-sprite.animate {
+    animation: chair-slide 0.9s ease-in-out;
+}
+
+@keyframes hero-slide {
+    0% { transform: translateX(-20px) translateY(0); }
+    40% { transform: translateX(0) translateY(-10px); }
+    70% { transform: translateX(18px) translateY(-4px); }
+    100% { transform: translateX(0) translateY(0); }
+}
+
+@keyframes chair-slide {
+    0% { transform: translateX(20px) translateY(0); }
+    40% { transform: translateX(0) translateY(-8px); }
+    70% { transform: translateX(-16px) translateY(-2px); }
+    100% { transform: translateX(0) translateY(0); }
+}
+
 #character-sprite-container {
     position: absolute;
     top: 0;


### PR DESCRIPTION
## Summary
- add a dedicated hero and chair container to the game screen so they are rendered at the top
- draw inline SVG sprites for the hero and chair and animate them simultaneously when choices are selected
- trigger the animation each time a new quest is loaded while preserving existing UI behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c96204daf08324ab9bc0d76ba2ab82